### PR TITLE
Fix script name in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ RadNight Technologies LLC
 1. Clone the repository.
 2. Run the provided Python script:  
    ```bash
-   python xcode_to_cmake.py
+   python xcodetocmake.py
    ```
 3. When prompted, enter the path to your `.xcodeproj` directory.
 4. Next, enter any dependencies your project requires, separated by spaces (e.g., `pthread OpenGL`).


### PR DESCRIPTION
attempting to run the command in README.md results in an error because the filename is slightly wrong; removing the underscores from the script path fixes it
(also maybe it'd be worthwhile to change `python` to `python3` while we're here?)
