### PR TITLE
Run `ruff check --fix`

### DIFF
--- a/xcodetocmake.py
+++ b/xcodetocmake.py
@@ -32,7 +32,7 @@ def create_cmake_lists(project_path, source_files):
     # Open a new CMakeLists.txt file in write mode
     with open('CMakeLists.txt', 'w') as cmake_file:
         # Write the minimum required CMake version
-        cmake_file.write(f"cmake_minimum_required(VERSION 3.10)\n")
+        cmake_file.write("cmake_minimum_required(VERSION 3.10)\n")
         # Write the project name
         cmake_file.write(f"project({project_name})\n\n")
         # Start the add_executable command

--- a/xcodetocmake_deps.py
+++ b/xcodetocmake_deps.py
@@ -48,7 +48,7 @@ def create_cmake_lists(project_path, files, dependencies, include_headers=True, 
     
     try:
         with open('CMakeLists.txt', 'w') as cmake_file:
-            cmake_file.write(f"cmake_minimum_required(VERSION 3.10)\n")
+            cmake_file.write("cmake_minimum_required(VERSION 3.10)\n")
             cmake_file.write(f"project({project_name})\n\n")
             
             # /* Add source files to the executable target */
@@ -76,8 +76,8 @@ def create_cmake_lists(project_path, files, dependencies, include_headers=True, 
             # /* Conditionally handle resources */
             if include_resources and files['resources']:
                 cmake_file.write("\n# Resources\n")
-                cmake_file.write(f"set(RESOURCE_DIR ${{CMAKE_BINARY_DIR}}/Resources)\n")
-                cmake_file.write(f"file(MAKE_DIRECTORY ${{RESOURCE_DIR}})\n")
+                cmake_file.write("set(RESOURCE_DIR ${CMAKE_BINARY_DIR}/Resources)\n")
+                cmake_file.write("file(MAKE_DIRECTORY ${RESOURCE_DIR})\n")
                 for resource in files['resources']:
                     cmake_file.write(f"file(COPY {resource} DESTINATION ${{RESOURCE_DIR}})\n")
             


### PR DESCRIPTION
I ran `ruff check` and got this output:
```
$ ruff check
xcodetocmake.py:35:26: F541 [*] f-string without any placeholders
   |
33 |     with open('CMakeLists.txt', 'w') as cmake_file:
34 |         # Write the minimum required CMake version
35 |         cmake_file.write(f"cmake_minimum_required(VERSION 3.10)\n")
   |                          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ F541
36 |         # Write the project name
37 |         cmake_file.write(f"project({project_name})\n\n")
   |
   = help: Remove extraneous `f` prefix

xcodetocmake_deps.py:51:30: F541 [*] f-string without any placeholders
   |
49 |     try:
50 |         with open('CMakeLists.txt', 'w') as cmake_file:
51 |             cmake_file.write(f"cmake_minimum_required(VERSION 3.10)\n")
   |                              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ F541
52 |             cmake_file.write(f"project({project_name})\n\n")
   |
   = help: Remove extraneous `f` prefix

xcodetocmake_deps.py:70:64: F821 Undefined name `PROJECT_NAME`
   |
68 |                 for framework in files['frameworks']:
69 |                     framework_name = os.path.basename(framework).replace(".framework", "")
70 |                     cmake_file.write(f"target_link_libraries(${PROJECT_NAME} {framework_name})\n")
   |                                                                ^^^^^^^^^^^^ F821
71 |             
72 |             # /* Link additional user-specified dependencies */
   |

xcodetocmake_deps.py:74:60: F821 Undefined name `PROJECT_NAME`
   |
72 |             # /* Link additional user-specified dependencies */
73 |             for dep in dependencies:
74 |                 cmake_file.write(f"target_link_libraries(${PROJECT_NAME} {dep})\n")
   |                                                            ^^^^^^^^^^^^ F821
75 | 
76 |             # /* Conditionally handle resources */
   |

xcodetocmake_deps.py:79:34: F541 [*] f-string without any placeholders
   |
77 |             if include_resources and files['resources']:
78 |                 cmake_file.write("\n# Resources\n")
79 |                 cmake_file.write(f"set(RESOURCE_DIR ${{CMAKE_BINARY_DIR}}/Resources)\n")
   |                                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ F541
80 |                 cmake_file.write(f"file(MAKE_DIRECTORY ${{RESOURCE_DIR}})\n")
81 |                 for resource in files['resources']:
   |
   = help: Remove extraneous `f` prefix

xcodetocmake_deps.py:80:34: F541 [*] f-string without any placeholders
   |
78 |                 cmake_file.write("\n# Resources\n")
79 |                 cmake_file.write(f"set(RESOURCE_DIR ${{CMAKE_BINARY_DIR}}/Resources)\n")
80 |                 cmake_file.write(f"file(MAKE_DIRECTORY ${{RESOURCE_DIR}})\n")
   |                                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ F541
81 |                 for resource in files['resources']:
82 |                     cmake_file.write(f"file(COPY {resource} DESTINATION ${{RESOURCE_DIR}})\n")
   |
   = help: Remove extraneous `f` prefix

Found 6 errors.
[*] 4 fixable with the `--fix` option.
```
So, I applied its suggestions. Note: I'm not sure if these changes are correct or not; please review... 